### PR TITLE
:clock1130: store and expose last update datetimestamp

### DIFF
--- a/pages/api/last-updated.js
+++ b/pages/api/last-updated.js
@@ -1,0 +1,9 @@
+import fetch from "isomorphic-fetch"
+
+const jsonPromise = fetch(
+	`https://brasil.io/api/dataset/covid19`
+).then((r) => r.json());
+
+export default (req, res) => {
+	jsonPromise.then((json) => res.status(200).json({ lastUpdate: json.tables[1].import_date }))
+}


### PR DESCRIPTION
This is the first of two PR's to only run a deployment when new data is available. It's not the cleanest, would have loved to generate a static file in `public` instead but we're not building `Docker` images so that's a bit harder.